### PR TITLE
yocto 3.1 dunfell build fixes

### DIFF
--- a/cobalt_source.cc
+++ b/cobalt_source.cc
@@ -94,7 +94,7 @@ static void gst_cobalt_src_class_init(GstCobaltSrcClass* klass)
 
 static void gst_cobalt_src_init(GstCobaltSrc* src)
 {
-  GstCobaltSrcPrivate* priv = GST_COBALT_SRC_GET_PRIVATE(src);
+  GstCobaltSrcPrivate* priv = (GstCobaltSrcPrivate*)gst_cobalt_src_get_instance_private(src);
   src->priv = priv;
   src->priv->configured = FALSE;
   src->priv->pad_counter = 0;

--- a/compiler_flags.gypi
+++ b/compiler_flags.gypi
@@ -52,6 +52,8 @@
       '-Wno-unused-parameter',
       # fix for #if, #elif are not portable defines in gcc 9.3 or above
       '-Wno-expansion-to-defined',
+      # fix for offsetof() usage
+      '-Wno-invalid-offsetof'
       
       '-I=/usr/include',
       '-I=/usr/include/interface/vcos/pthreads',


### PR DESCRIPTION
| .../third_party/starboard/raspi/wayland/starboard_platform.cobalt_source.o
| ../../third_party/starboard/raspi/wayland/cobalt_source.cc:97:13: error: G_ADD_PRIVATE [-Werror]
|    97 |   GstCobaltSrcPrivate* priv = GST_COBALT_SRC_GET_PRIVATE(src);
|       |             ^~~~~~~~~~~~~~~
| cc1plus: all warnings being treated as errors